### PR TITLE
Make `--discover` output YAML-ish

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,12 @@ Usage: bin/fsmanage {--spec PATH | --discover | --delete-all}
     	Delete all mount targets, file systems, and access points.
   -discover
     	Discover and print file system and access point pairs, one per line, e.g.
-    	    fs-a99c122a:fsap-099537fb4bb7d50ea
-    	    fs-b89c123b:fsap-04e855ae78fe51eed
-    	    fs-b89c123b:fsap-0b02dc545c4f9b076
+            fs-95611e16: []
+            fs-94611e17:
+              - fsap-0c653ba4711f0d167
+              - fsap-0fef2eff6c96ac5c8
+            fs-96611e15:
+              - fsap-0f1a063e6ebac6db6
   -spec string
     	Path to a YAML spec file describing the desired file system and access point state.
     	The file represents a map, keyed by file system "token", of lists of access point "tokens".

--- a/pkg/efsmanage/client.go
+++ b/pkg/efsmanage/client.go
@@ -407,8 +407,14 @@ func discoverPrint() {
 	efssvc := getEFS(sess)
 	currentState := getFileSystems(efssvc)
 	for _, fs := range currentState {
-		for _, ap := range fs.accessPoints {
-			fmt.Printf("%s:%s\n", fs.fileSystemID, ap)
+		fmt.Printf("%s:", fs.fileSystemID)
+		if len(fs.accessPoints) == 0 {
+			fmt.Print(" []\n")
+		} else {
+			fmt.Print("\n")
+			for _, ap := range fs.accessPoints {
+				fmt.Printf("  - %s\n", ap)
+			}
 		}
 	}
 }

--- a/pkg/efsmanage/main.go
+++ b/pkg/efsmanage/main.go
@@ -47,9 +47,14 @@ have two access points; the third will have none.`)
 		"discover",
 		false,
 		`Discover and print file system and access point pairs, one per line, e.g.
-    fs-a99c122a:fsap-099537fb4bb7d50ea
-    fs-b89c123b:fsap-04e855ae78fe51eed
-    fs-b89c123b:fsap-0b02dc545c4f9b076`)
+
+    fs-95611e16: []
+    fs-94611e17:
+      - fsap-0c653ba4711f0d167
+      - fsap-0fef2eff6c96ac5c8
+    fs-96611e15:
+      - fsap-0f1a063e6ebac6db6
+`)
 
 	flag.Parse()
 


### PR DESCRIPTION
There was a bug in that `--discover` would miss displaying file systems
with no access points. Resolve this by making the output the same shape
as the `--spec` input: namely a YAML-compliant map, keyed by file system
ID, of lists of access point IDs. If a file system has no access points,
the empty list (`[]`) is explicitly shown.